### PR TITLE
added memory map file for relgroup - fix neo4j config missing line

### DIFF
--- a/node/neo4j.properties
+++ b/node/neo4j.properties
@@ -4,6 +4,7 @@
 #neostore.propertystore.db.mapped_memory=90M
 #neostore.propertystore.db.strings.mapped_memory=130M
 #neostore.propertystore.db.arrays.mapped_memory=130M
+neostore.relationshipgroupstore.db.mapped_memory=10M
 
 #node_auto_indexing=true
 #node_keys_indexable=name,age


### PR DESCRIPTION
In Neo4j 2.1.6, there is a missing configuration line in `neo4j.properties` leading to the relationgroup file to not be memory mapped and thus always hitting disk for some read queries. 

This is a known bug at neo.

This setting speeds up by 10% read queries on grouped relationships. Write queries always hits disk anyway.
